### PR TITLE
Add audience pages and navigation

### DIFF
--- a/elderly.html
+++ b/elderly.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Ping15 lets you give loved ones quick moments of voice." />
+  <title>Ping15 for the Elderly</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav class="main-nav reveal">
+    <a href="index.html" class="logo">Ping15</a>
+    <a href="young.html">Young People</a>
+    <a href="elderly.html" class="active">Elderly</a>
+    <a href="longdistance.html">Long-Distance</a>
+  </nav>
+  <div class="background">
+    <span style="left:10%; top:20%;"></span>
+    <span style="left:70%; top:60%; animation-delay:3s;"></span>
+    <span style="left:40%; top:80%; animation-delay:6s;"></span>
+  </div>
+  <header class="hero">
+    <h1 class="headline">You don’t need long to feel close.</h1>
+    <p class="subheadline">For grandparents, relatives, and friends who just want to hear your voice.</p>
+    <img src="https://images.unsplash.com/photo-1609743528063-bb55db81c7fa?w=600" alt="Elderly person happily using a phone" class="hero-image"/>
+  </header>
+  <main>
+    <section class="testimonials">
+      <blockquote class="quote">
+        <p>"My grandson pings me every Sunday. It’s our little thing now."</p>
+      </blockquote>
+    </section>
+    <section class="use-cases" id="use">
+      <h2>Use cases</h2>
+      <ul>
+        <li>A quick check-in</li>
+        <li>A ritual call after lunch</li>
+        <li>A ping from a care volunteer</li>
+      </ul>
+    </section>
+    <section class="signup">
+      <h2>Give them 15 seconds of love.</h2>
+      <form id="emailForm">
+        <input type="email" id="email" placeholder="you@example.com" required>
+        <button type="submit">Be one of the first to Ping</button>
+      </form>
+      <div id="thanks" class="hidden">Thank you! 🎉</div>
+    </section>
+  </main>
+  <button class="cta" id="cta">Join the beta</button>
+  <button id="modeToggle" class="mode-toggle">🌙</button>
+  <footer>
+    <nav>
+      <a href="#about">About</a>
+      <a href="#privacy">Privacy</a>
+      <a href="#contact">Contact</a>
+    </nav>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,12 @@
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+  <nav class="main-nav reveal">
+    <a href="index.html" class="logo active">Ping15</a>
+    <a href="young.html">Young People</a>
+    <a href="elderly.html">Elderly</a>
+    <a href="longdistance.html">Long-Distance</a>
+  </nav>
   <div class="background">
     <span style="left:10%; top:20%;"></span>
     <span style="left:70%; top:60%; animation-delay:3s;"></span>

--- a/longdistance.html
+++ b/longdistance.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Ping15 keeps busy friends and long-distance couples feeling close." />
+  <title>Ping15 for Long-Distance</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav class="main-nav reveal">
+    <a href="index.html" class="logo">Ping15</a>
+    <a href="young.html">Young People</a>
+    <a href="elderly.html">Elderly</a>
+    <a href="longdistance.html" class="active">Long-Distance</a>
+  </nav>
+  <div class="background">
+    <span style="left:10%; top:20%;"></span>
+    <span style="left:70%; top:60%; animation-delay:3s;"></span>
+    <span style="left:40%; top:80%; animation-delay:6s;"></span>
+  </div>
+  <header class="hero">
+    <h1 class="headline">When timezones don’t line up, 15 seconds do.</h1>
+    <p class="subheadline">Ping15 lets you stay close — even when you’re far apart.</p>
+    <img src="https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=600" alt="Two people smiling while far apart" class="hero-image"/>
+  </header>
+  <main>
+    <section class="testimonials">
+      <blockquote class="quote">
+        <p>"My partner works nights. I ping her goodnight every day."</p>
+      </blockquote>
+    </section>
+    <section class="use-cases" id="use">
+      <h2>Use cases</h2>
+      <ul>
+        <li>Long-distance relationships</li>
+        <li>Remote teams</li>
+        <li>Friends who can’t sync schedules</li>
+      </ul>
+    </section>
+    <section class="signup">
+      <h2>Stay connected. No pressure.</h2>
+      <form id="emailForm">
+        <input type="email" id="email" placeholder="you@example.com" required>
+        <button type="submit">Be one of the first to Ping</button>
+      </form>
+      <div id="thanks" class="hidden">Thank you! 🎉</div>
+    </section>
+  </main>
+  <button class="cta" id="cta">Join the beta</button>
+  <button id="modeToggle" class="mode-toggle">🌙</button>
+  <footer>
+    <nav>
+      <a href="#about">About</a>
+      <a href="#privacy">Privacy</a>
+      <a href="#contact">Contact</a>
+    </nav>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@ const observer = new IntersectionObserver(entries => {
 });
 
 // observe elements
-['.headline', '.subheadline', '.phone-mockup', '.card', '.use-cases li', '.testimonials blockquote'].forEach(sel => {
+['.main-nav', '.headline', '.subheadline', '.hero-image', '.phone-mockup', '.card', '.use-cases li', '.testimonials blockquote'].forEach(sel => {
   document.querySelectorAll(sel).forEach(el => observer.observe(el));
 });
 
@@ -60,14 +60,27 @@ toggle.addEventListener('click', () => {
   toggle.textContent = dark ? '☀️' : '🌙';
 });
 
-// countdown demo
+// countdown demo (home page)
 const timerEl = document.getElementById('timer');
-let time = 15;
-function tick() {
-  timerEl.textContent = time;
-  if (time === 0) {
-    clearInterval(countdown);
+if (timerEl) {
+  let time = 15;
+  function tick() {
+    timerEl.textContent = time;
+    if (time === 0) {
+      clearInterval(countdown);
+    }
+    time--;
   }
-  time--;
+  const countdown = setInterval(tick, 1000);
 }
-const countdown = setInterval(tick, 1000);
+
+// nav scroll effect
+const nav = document.querySelector('.main-nav');
+window.addEventListener('scroll', () => {
+  if (!nav) return;
+  if (window.scrollY > 10) {
+    nav.classList.add('scrolled');
+  } else {
+    nav.classList.remove('scrolled');
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -23,6 +23,55 @@ body {
   color: var(--text);
   overflow-x: hidden;
 }
+
+/* navigation */
+.main-nav {
+  position: sticky;
+  top: 0;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.5rem 1rem;
+  background: var(--bg);
+  z-index: 100;
+  transform: translateY(-40px);
+  opacity: 0;
+  transition: var(--transition);
+}
+.main-nav.reveal {
+  transform: translateY(0);
+  opacity: 1;
+}
+.main-nav.scrolled {
+  box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+}
+.main-nav .logo {
+  font-weight: 600;
+  margin-right: auto;
+  text-decoration: none;
+  color: var(--text);
+}
+.main-nav a {
+  text-decoration: none;
+  color: var(--text);
+  padding: 0.25rem 0;
+  position: relative;
+  opacity: 0.8;
+  transition: var(--transition);
+}
+.main-nav a:hover {
+  opacity: 1;
+}
+.main-nav a.active::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -2px;
+  height: 2px;
+  background: var(--accent);
+  border-radius: 2px;
+}
 .hero {
   padding: 4rem 1rem;
   text-align: center;
@@ -52,6 +101,16 @@ body {
 }
 .phone {
   width: 100%;
+}
+.hero-image {
+  width: 80%;
+  max-width: 300px;
+  margin: 0 auto;
+  display: block;
+  border-radius: 10px;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: var(--transition) 0.4s;
 }
 .features {
   display: flex;

--- a/young.html
+++ b/young.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Ping15 helps phone-anxious young people reach out without fear." />
+  <title>Ping15 for Young People</title>
+  <link rel="preconnect" href="https://fonts.gstatic.com">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <nav class="main-nav reveal">
+    <a href="index.html" class="logo">Ping15</a>
+    <a href="young.html" class="active">Young People</a>
+    <a href="elderly.html">Elderly</a>
+    <a href="longdistance.html">Long-Distance</a>
+  </nav>
+  <div class="background">
+    <span style="left:10%; top:20%;"></span>
+    <span style="left:70%; top:60%; animation-delay:3s;"></span>
+    <span style="left:40%; top:80%; animation-delay:6s;"></span>
+  </div>
+  <header class="hero">
+    <h1 class="headline">Connection without panic.</h1>
+    <p class="subheadline">Ping15 helps phone-anxious young people reach out without fear.</p>
+    <img src="https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?w=600" alt="Calm young person using phone" class="hero-image"/>
+  </header>
+  <main>
+    <section class="testimonials">
+      <blockquote class="quote">
+        <p>"15 seconds is all I needed to feel less alone."</p>
+      </blockquote>
+    </section>
+    <section class="use-cases" id="use">
+      <h2>Use cases</h2>
+      <ul>
+        <li>Ping your roommate after a fight</li>
+        <li>Say hi to your mom without worrying she'll keep you on the phone</li>
+      </ul>
+    </section>
+    <section class="signup">
+      <h2>Start small. Start safe.</h2>
+      <form id="emailForm">
+        <input type="email" id="email" placeholder="you@example.com" required>
+        <button type="submit">Be one of the first to Ping</button>
+      </form>
+      <div id="thanks" class="hidden">Thank you! 🎉</div>
+    </section>
+  </main>
+  <button class="cta" id="cta">Join the beta</button>
+  <button id="modeToggle" class="mode-toggle">🌙</button>
+  <footer>
+    <nav>
+      <a href="#about">About</a>
+      <a href="#privacy">Privacy</a>
+      <a href="#contact">Contact</a>
+    </nav>
+  </footer>
+  <script src="script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add sticky navigation and hero image styles
- implement nav scroll effect in JavaScript and guard countdown for other pages
- add three audience-focused landing pages: young, elderly and longdistance
- update homepage with navigation links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685032fab84c83298239a32e98f386fc